### PR TITLE
[AN-121] Endpoints for assigning wrestlers to tournaments

### DIFF
--- a/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/api/controller/v1/CategoryController.java
+++ b/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/api/controller/v1/CategoryController.java
@@ -2,7 +2,9 @@ package com.sumoc.sumochampionship.api.controller.v1;
 
 import com.sumoc.sumochampionship.api.dto.category.CategoryDto;
 import com.sumoc.sumochampionship.api.dto.category.CategoriesResponse;
+import com.sumoc.sumochampionship.api.dto.category.CategoryDto2;
 import com.sumoc.sumochampionship.service.CategoryService;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -35,5 +37,22 @@ public class CategoryController {
         return ResponseEntity.ok(categoryService.getAllCategories());
 
     }
+
+    /*
+    Get all categories that Tournament has
+     */
+    @GetMapping("/to-tournament")
+    public ResponseEntity<List<CategoryDto2>> getTournamentCategories(@RequestParam Long tournamentId){
+        List<CategoryDto2> categories = null;
+
+        try{
+            categories = categoryService.getTournamentCategories(tournamentId);
+        }catch (EntityNotFoundException e){
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(categories);
+    }
+
 
 }

--- a/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/api/controller/v1/ClubController.java
+++ b/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/api/controller/v1/ClubController.java
@@ -42,11 +42,14 @@ public class ClubController {
     }
 
          /*
-    TODO: Test it after implementing login / register.
-    Get All clubs that can be accessed by user (example: Admin may access all clubs)
+        TODO: Test it after implementing login / register.
+        Get All clubs that can be accessed by user (example: Admin may access all clubs)
      */
         @GetMapping("/to-user")
         public ResponseEntity<List<ClubDto>> getClubsToUser(@AuthenticationPrincipal WebsiteUser user){
+            if (user == null){
+                return ResponseEntity.status(401).build();
+            }
             return ResponseEntity.ok(clubService.getAllClubsToUser(user));
         }
 

--- a/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/api/controller/v1/ClubController.java
+++ b/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/api/controller/v1/ClubController.java
@@ -1,5 +1,6 @@
 package com.sumoc.sumochampionship.api.controller.v1;
 
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -8,24 +9,61 @@ import com.sumoc.sumochampionship.service.ClubService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import com.sumoc.sumochampionship.api.dto.club.ClubDto;
+import com.sumoc.sumochampionship.db.people.WebsiteUser;
+import com.sumoc.sumochampionship.service.ClubService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @CrossOrigin
 @RestController
 @RequestMapping("api/v1/club")
 public class ClubController {
+
     private final ClubService clubService;
 
     @PostMapping("/add")
-    public ResponseEntity<JsonNode> addClub(@RequestBody ClubRequest clubRequest){
+    public ResponseEntity<JsonNode> addClub(@RequestBody ClubRequest clubRequest) {
         String response = clubService.addClub(clubRequest);
         ObjectMapper objectMapper = new ObjectMapper();
         ObjectNode json = objectMapper.createObjectNode();
         json.put("response", response);
 
-        if (response.startsWith("Error!")){
+        if (response.startsWith("Error!")) {
             return ResponseEntity.badRequest().body(json);
         }
         return ResponseEntity.ok(json);
+    }
+
+         /*
+    TODO: Test it after implementing login / register.
+    Get All clubs that can be accessed by user (example: Admin may access all clubs)
+     */
+        @GetMapping("/to-user")
+        public ResponseEntity<List<ClubDto>> getClubsToUser(@AuthenticationPrincipal WebsiteUser user){
+            return ResponseEntity.ok(clubService.getAllClubsToUser(user));
+        }
+
+    /*
+    Get club to wrestler
+     */
+        @GetMapping("/to-wrestler")
+        public ResponseEntity<ClubDto> getClubToWrestler(@RequestParam Long wrestlerId){
+            ClubDto club = null;
+
+            try{
+                club = clubService.getClubToWrestler(wrestlerId);
+            }catch (EntityNotFoundException e){
+                return ResponseEntity.notFound().build();
+            }
+
+            return ResponseEntity.ok(club);
+
     }
 }

--- a/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/api/controller/v1/WrestlerController.java
+++ b/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/api/controller/v1/WrestlerController.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.sumoc.sumochampionship.api.dto.wrestler.WrestlerDetails;
 import com.sumoc.sumochampionship.api.dto.wrestler.WrestlerRequest;
+import com.sumoc.sumochampionship.api.dto.wrestler.WrestlersDto;
 import com.sumoc.sumochampionship.api.dto.wrestler.WrestlersResponse;
 import com.sumoc.sumochampionship.db.people.WebsiteUser;
 import com.sumoc.sumochampionship.service.WrestlerService;
@@ -16,6 +17,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * Controller responsible for manipulating request given by Website Users
@@ -91,6 +94,26 @@ public class WrestlerController {
             return ResponseEntity.badRequest().body(json);
         }
         return ResponseEntity.ok(json);
+    }
+
+    @GetMapping("/fit-to-category")
+    public ResponseEntity<List<WrestlersDto>> filterWrestlerToClub(
+            @AuthenticationPrincipal WebsiteUser user,
+            @RequestParam(name = "categoryId") Long categoryId){
+
+        // User is not logged
+        if (user == null){
+            return ResponseEntity.status(401).build();
+        }
+
+        List<WrestlersDto> response = null;
+        try{
+            response = wrestlerService.filterWrestler(user, categoryId);
+        }catch (EntityNotFoundException e){
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/api/controller/v1/WrestlerEnrollmentController.java
+++ b/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/api/controller/v1/WrestlerEnrollmentController.java
@@ -1,0 +1,38 @@
+package com.sumoc.sumochampionship.api.controller.v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sumoc.sumochampionship.api.dto.wrestlerenrollment.WrestlerEnrollmentRequest;
+import com.sumoc.sumochampionship.db.season.WrestlersEnrollment;
+import com.sumoc.sumochampionship.service.WrestlerEnrollmentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@CrossOrigin
+@RestController
+@RequestMapping("/api/v1/wrestler-enrollment")
+public class WrestlerEnrollmentController {
+
+    private final WrestlerEnrollmentService wrestlerEnrollmentService;
+
+    @PostMapping("/enroll-wrestlers")
+    public ResponseEntity<JsonNode> enrollWrestlers(@RequestBody List<WrestlerEnrollmentRequest> enrollments){
+        String response = wrestlerEnrollmentService.enrollWrestlers(enrollments);
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode json = objectMapper.createObjectNode();
+        json.put("response", response);
+
+        if (response.startsWith("Error!")){
+            return ResponseEntity.badRequest().body(json);
+        }
+        return ResponseEntity.ok(json);
+
+    }
+
+
+}

--- a/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/api/dto/category/CategoryDto2.java
+++ b/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/api/dto/category/CategoryDto2.java
@@ -35,7 +35,6 @@ public class CategoryDto2 {
         this.maxAge = maxAge;
         this.weightsAndGender = weightsAndGender;
     }
-
     public static List<CategoryDto2> mapListToDto(List<Category> categories){
         HashMap<String, List<WeightDetailsRequest>> ageCategoryToWeights = new HashMap<>();
         HashMap<String, Pair<Integer, Integer>> categoryNameToAges = new HashMap<>();

--- a/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/api/dto/club/ClubDto.java
+++ b/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/api/dto/club/ClubDto.java
@@ -1,0 +1,28 @@
+package com.sumoc.sumochampionship.api.dto.club;
+
+import com.sumoc.sumochampionship.db.people.Club;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ClubDto {
+
+    private Long id;
+    private String name;
+    private String nationality;
+
+
+
+    public static ClubDto mapToDto(Club club){
+        return ClubDto.builder()
+                .id(club.getId())
+                .name(club.getName())
+                .nationality(club.getNationality())
+                .build();
+    }
+}

--- a/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/api/dto/wrestlerenrollment/WrestlerEnrollmentRequest.java
+++ b/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/api/dto/wrestlerenrollment/WrestlerEnrollmentRequest.java
@@ -1,0 +1,20 @@
+package com.sumoc.sumochampionship.api.dto.wrestlerenrollment;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class WrestlerEnrollmentRequest {
+
+    private Long tournamentId;
+    private Long wrestlerId;
+    private List<Long> categoriesId;
+
+}

--- a/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/db/people/Wrestler.java
+++ b/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/db/people/Wrestler.java
@@ -6,8 +6,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.cglib.core.Local;
 
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.Set;
 
 /**
@@ -41,5 +43,11 @@ public class Wrestler {
     @OneToMany(mappedBy = "wrestler")
     private Set<WrestlersEnrollment> enrollments;
 
+
+    public boolean availableForCategory(Integer minAge, Integer maxAge){
+        long age = ChronoUnit.YEARS.between(birthday, LocalDate.now());
+
+        return minAge <= age && age <= maxAge;
+    }
 
 }

--- a/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/db/season/WrestlersEnrollment.java
+++ b/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/db/season/WrestlersEnrollment.java
@@ -15,6 +15,7 @@ import lombok.NoArgsConstructor;
 public class WrestlersEnrollment {
 
     @Id
+    @GeneratedValue
     private Long id;
 
     @ManyToOne

--- a/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/repository/CategoryRepository.java
+++ b/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/repository/CategoryRepository.java
@@ -2,6 +2,7 @@ package com.sumoc.sumochampionship.repository;
 
 import com.sumoc.sumochampionship.db.season.Category;
 import com.sumoc.sumochampionship.db.season.Season;
+import com.sumoc.sumochampionship.db.season.Tournament;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/repository/ClubRepository.java
+++ b/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/repository/ClubRepository.java
@@ -1,10 +1,13 @@
 package com.sumoc.sumochampionship.repository;
 
 import com.sumoc.sumochampionship.db.people.Club;
+import com.sumoc.sumochampionship.db.people.WebsiteUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface ClubRepository extends JpaRepository<Club, Long> {

--- a/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/repository/WrestlerRepository.java
+++ b/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/repository/WrestlerRepository.java
@@ -26,5 +26,6 @@ public interface WrestlerRepository extends JpaRepository<Wrestler, Long> {
         belongs to polish club's
      */
     Page<Wrestler> findWrestlerByClubIn(Collection<Club> club, Pageable pageable);
+    List<Wrestler> findAllByClubIn(Set<Club> clubs);
 
 }

--- a/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/service/CategoryService.java
+++ b/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/service/CategoryService.java
@@ -5,7 +5,10 @@ import com.sumoc.sumochampionship.api.dto.category.CategoryDto;
 import com.sumoc.sumochampionship.api.dto.category.CategoriesResponse;
 import com.sumoc.sumochampionship.api.dto.category.CategoryDto2;
 import com.sumoc.sumochampionship.db.season.Category;
+import com.sumoc.sumochampionship.db.season.Tournament;
 import com.sumoc.sumochampionship.repository.CategoryRepository;
+import com.sumoc.sumochampionship.repository.TournamentRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -13,12 +16,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
 public class CategoryService {
 
     private final CategoryRepository categoryRepository;
+    private final TournamentRepository tournamentRepository;
 
     /*
     Get categories that belong to Season.
@@ -48,6 +53,18 @@ public class CategoryService {
 
         return categories.stream().map(CategoryDto::toDto).toList();
 
+    }
+
+    public List<CategoryDto2> getTournamentCategories(Long tournamentId){
+
+        Optional<Tournament> tournamentOptional = tournamentRepository.findById(tournamentId);
+        if (tournamentOptional.isEmpty()){
+            throw new EntityNotFoundException("Tournament with id = " + tournamentId + " does not exists");
+        }
+
+        List<Category> categories = tournamentOptional.get().getCategories().stream().toList();
+
+        return CategoryDto2.mapListToDto(categories);
     }
 
     //-----------------------------API VERSION 2-----------------------------//

--- a/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/service/ClubService.java
+++ b/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/service/ClubService.java
@@ -1,17 +1,24 @@
 package com.sumoc.sumochampionship.service;
 
+import com.sumoc.sumochampionship.api.dto.club.ClubDto;
 import com.sumoc.sumochampionship.api.dto.club.ClubRequest;
 import com.sumoc.sumochampionship.db.people.Club;
+import com.sumoc.sumochampionship.db.people.WebsiteUser;
+import com.sumoc.sumochampionship.db.people.Wrestler;
 import com.sumoc.sumochampionship.repository.ClubRepository;
+import com.sumoc.sumochampionship.repository.WrestlerRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
 @AllArgsConstructor
 public class ClubService {
     private final ClubRepository clubRepository;
+    private final WrestlerRepository wrestlerRepository;
 
     public String addClub(ClubRequest clubRequest){
         Optional<Club> clubOptional = clubRepository.findByName(clubRequest.getName());
@@ -23,4 +30,27 @@ public class ClubService {
         clubRepository.save(club);
         return "Club added successfully";
     }
+
+    /*
+    Get all Clubs that should be accessed by users
+     */
+    public List<ClubDto> getAllClubsToUser(WebsiteUser user){
+        return user.getOwnedClubs().stream().map(ClubDto::mapToDto).toList();
+    }
+
+    /*
+    Get Club to Wrestler
+     */
+    public ClubDto getClubToWrestler(Long wrestlerId){
+        Optional<Wrestler> wrestlerOptional = wrestlerRepository.findById(wrestlerId);
+
+        if (wrestlerOptional.isEmpty()){
+            throw new EntityNotFoundException("Model not found");
+        }
+
+        Wrestler wrestler = wrestlerOptional.get();
+
+        return ClubDto.mapToDto(wrestler.getClub());
+    }
+
 }

--- a/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/service/WrestlerEnrollmentService.java
+++ b/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/service/WrestlerEnrollmentService.java
@@ -64,22 +64,26 @@ public class WrestlerEnrollmentService {
     private boolean mayWrestlerEnroll(WrestlerEnrollmentRequest request){
         Optional<Tournament> tournamentOptional = tournamentRepository.findById(request.getTournamentId());
 
-        if (tournamentOptional.isEmpty()) return false;
+        if (tournamentOptional.isEmpty())
+            return false;
 
         Optional<Wrestler> wrestlerOptional = wrestlerRepository.findById(request.getWrestlerId());
 
-        if (wrestlerOptional.isEmpty()) return false;
+        if (wrestlerOptional.isEmpty())
+            return false;
         Wrestler wrestler = wrestlerOptional.get();
 
         for(Long categoryId: request.getCategoriesId()){
             Optional<Category> categoryOptional = categoryRepository.findById(categoryId);
 
-            if(categoryOptional.isEmpty()) return false;
+            if(categoryOptional.isEmpty())
+                return false;
             Category category = categoryOptional.get();
 
             // Check age
-            long age = ChronoUnit.YEARS.between(LocalDate.now(), wrestler.getBirthday());
-            if(!(age >= category.getMinAge() && age <= category.getMaxAge())) return false;
+
+            if(!wrestler.availableForCategory(category.getMinAge(), category.getMaxAge()))
+                return false;
         }
 
         return true;

--- a/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/service/WrestlerEnrollmentService.java
+++ b/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/service/WrestlerEnrollmentService.java
@@ -1,23 +1,87 @@
 package com.sumoc.sumochampionship.service;
 
 import com.sumoc.sumochampionship.api.dto.enrollment.WrestlerEnrollmentDto;
+import com.sumoc.sumochampionship.api.dto.wrestlerenrollment.WrestlerEnrollmentRequest;
+import com.sumoc.sumochampionship.db.people.Wrestler;
+import com.sumoc.sumochampionship.db.season.Category;
+import com.sumoc.sumochampionship.db.season.Tournament;
 import com.sumoc.sumochampionship.db.season.WrestlersEnrollment;
+import com.sumoc.sumochampionship.repository.CategoryRepository;
+import com.sumoc.sumochampionship.repository.TournamentRepository;
 import com.sumoc.sumochampionship.repository.WrestlerEnrollmentRepository;
+import com.sumoc.sumochampionship.repository.WrestlerRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
 public class WrestlerEnrollmentService {
     private final WrestlerEnrollmentRepository wrestlerEnrollmentRepository;
+    private final TournamentRepository tournamentRepository;
+    private final WrestlerRepository wrestlerRepository;
+    private final CategoryRepository categoryRepository;
 
     public List<WrestlerEnrollmentDto> getWrestlerEnrollments(Long tournamentId) throws EntityNotFoundException {
         List<WrestlersEnrollment> wrestlerEnrollments = wrestlerEnrollmentRepository.findAllByTournament_Id(tournamentId);
         return wrestlerEnrollments.stream()
                 .map(WrestlerEnrollmentDto::toDto)
                 .toList();
+    }
+
+
+    public String enrollWrestlers(List<WrestlerEnrollmentRequest> request) {
+
+        // Check if all wrestlers has got authority to enroll
+        for (WrestlerEnrollmentRequest wr : request) {
+            if (!mayWrestlerEnroll(wr)) {
+                return "Error! Provided wrong enrollment";
+            }
+            Tournament tournament = tournamentRepository.findById(wr.getTournamentId()).get();
+
+            Wrestler wrestler = wrestlerRepository.findById(wr.getWrestlerId()).get();
+
+            for (Long categoryId : wr.getCategoriesId()) {
+                Category category = categoryRepository.findById(categoryId).get();
+
+                wrestlerEnrollmentRepository.save(WrestlersEnrollment.builder()
+                                                    .wrestler(wrestler)
+                                                    .category(category)
+                                                    .tournament(tournament)
+                                                    .build());
+
+            }
+        }
+        return "Wrestlers enrolled";
+    }
+
+
+    private boolean mayWrestlerEnroll(WrestlerEnrollmentRequest request){
+        Optional<Tournament> tournamentOptional = tournamentRepository.findById(request.getTournamentId());
+
+        if (tournamentOptional.isEmpty()) return false;
+
+        Optional<Wrestler> wrestlerOptional = wrestlerRepository.findById(request.getWrestlerId());
+
+        if (wrestlerOptional.isEmpty()) return false;
+        Wrestler wrestler = wrestlerOptional.get();
+
+        for(Long categoryId: request.getCategoriesId()){
+            Optional<Category> categoryOptional = categoryRepository.findById(categoryId);
+
+            if(categoryOptional.isEmpty()) return false;
+            Category category = categoryOptional.get();
+
+            // Check age
+            long age = ChronoUnit.YEARS.between(LocalDate.now(), wrestler.getBirthday());
+            if(!(age >= category.getMinAge() && age <= category.getMaxAge())) return false;
+        }
+
+        return true;
     }
 }

--- a/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/service/WrestlerService.java
+++ b/backend/sumo-championship/src/main/java/com/sumoc/sumochampionship/service/WrestlerService.java
@@ -49,8 +49,8 @@ public class WrestlerService {
         Set<Club> ownedClubs = user.getOwnedClubs();
         Page<Wrestler> wrestlerPage = wrestlerRepository.findWrestlerByClubIn(ownedClubs, pageable);
 
-        List<Wrestler> listOfPokemon = wrestlerPage.getContent();
-        List<WrestlersDto> content = listOfPokemon.stream().map(WrestlersDto::mapToDto).toList();
+        List<Wrestler> listOfWrestlers = wrestlerPage.getContent();
+        List<WrestlersDto> content = listOfWrestlers.stream().map(WrestlersDto::mapToDto).toList();
 
         return WrestlersResponse.builder()
                 .wrestlersInfo(content)

--- a/backend/sumo-championship/src/test/java/com/sumoc/sumochampionship/repository/CategoryRepositoryTest.java
+++ b/backend/sumo-championship/src/test/java/com/sumoc/sumochampionship/repository/CategoryRepositoryTest.java
@@ -13,12 +13,16 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.TestPropertySource;
 
 import java.time.LocalDate;
 import java.util.List;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
+@TestPropertySource(properties = {
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect"
+})
 public class CategoryRepositoryTest {
 
     @Autowired

--- a/backend/sumo-championship/src/test/java/com/sumoc/sumochampionship/repository/LocationRepositoryTest.java
+++ b/backend/sumo-championship/src/test/java/com/sumoc/sumochampionship/repository/LocationRepositoryTest.java
@@ -7,11 +7,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
+@TestPropertySource(properties = {
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect"
+})
 class LocationRepositoryTest {
 
     @Autowired

--- a/backend/sumo-championship/src/test/java/com/sumoc/sumochampionship/repository/SeasonRepositoryTest.java
+++ b/backend/sumo-championship/src/test/java/com/sumoc/sumochampionship/repository/SeasonRepositoryTest.java
@@ -12,12 +12,16 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.test.context.TestPropertySource;
 
 import java.time.LocalDate;
 import java.util.List;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
+@TestPropertySource(properties = {
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect"
+})
 public class SeasonRepositoryTest {
 
     @Autowired
@@ -50,15 +54,6 @@ public class SeasonRepositoryTest {
         Assertions.assertEquals(2, seasons.size());
         Assertions.assertEquals("2024", seasons.get(0).getName());
         Assertions.assertEquals("2024-2", seasons.get(1).getName());
-    }
-
-    @Test
-    void  findById(){
-        // Act
-        Season season = seasonRepository.findById(1);
-
-        // Assertions
-        Assertions.assertEquals("2023", season.getName());
     }
 
     @BeforeEach

--- a/backend/sumo-championship/src/test/java/com/sumoc/sumochampionship/repository/TournamentRepositoryTest.java
+++ b/backend/sumo-championship/src/test/java/com/sumoc/sumochampionship/repository/TournamentRepositoryTest.java
@@ -7,11 +7,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
+@TestPropertySource(properties = {
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect"
+})
 class TournamentRepositoryTest {
 
     @Autowired
@@ -50,4 +54,6 @@ class TournamentRepositoryTest {
         assertNotNull(tournament);
         assertEquals("Tournament 03", tournament.getName());
     }
+
+
 }

--- a/backend/sumo-championship/src/test/java/com/sumoc/sumochampionship/repository/WrestlerRepositoryTest.java
+++ b/backend/sumo-championship/src/test/java/com/sumoc/sumochampionship/repository/WrestlerRepositoryTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.TestPropertySource;
 
 import java.time.LocalDate;
 import java.time.Month;
@@ -23,6 +24,9 @@ import java.util.Set;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
+@TestPropertySource(properties = {
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect"
+})
 class WrestlerRepositoryTest {
 
     @Autowired

--- a/backend/sumo-championship/src/test/java/com/sumoc/sumochampionship/service/CategoryServiceTest.java
+++ b/backend/sumo-championship/src/test/java/com/sumoc/sumochampionship/service/CategoryServiceTest.java
@@ -1,0 +1,64 @@
+package com.sumoc.sumochampionship.service;
+
+import com.sumoc.sumochampionship.api.dto.category.CategoryDto2;
+import com.sumoc.sumochampionship.db.season.Category;
+import com.sumoc.sumochampionship.db.season.Tournament;
+import com.sumoc.sumochampionship.repository.TournamentRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class CategoryServiceTest {
+
+    @Mock
+    private TournamentRepository tournamentRepository;
+
+
+    @InjectMocks
+    private CategoryService categoryService;
+
+
+    /*
+    Test if method returns correct categories in correct format
+     */
+    @Test
+    public void getTournamentCategories(){
+        // Arrange
+        final int categoryNo = 5;
+        Set<Category> categorySet = new HashSet<>();
+
+        for(int i = 0; i < categoryNo; i++){
+            categorySet.add(Category.builder()
+                            .name("Junior")
+                            .maxWeight(i + 1)
+                            .build());
+        }
+
+        Tournament tournament = Tournament.builder()
+                .categories(categorySet)
+                .build();
+
+        when(tournamentRepository.findById(Mockito.anyLong())).thenReturn(Optional.of(tournament));
+
+        // Act
+        List<CategoryDto2> categories = categoryService.getTournamentCategories(1L);
+
+        // Assert
+        Assertions.assertEquals(1, categories.size());
+        Assertions.assertEquals(categoryNo, categories.get(0).getWeightsAndGender().size());
+
+    }
+
+}

--- a/backend/sumo-championship/src/test/java/com/sumoc/sumochampionship/service/ClubServiceTest.java
+++ b/backend/sumo-championship/src/test/java/com/sumoc/sumochampionship/service/ClubServiceTest.java
@@ -1,0 +1,54 @@
+package com.sumoc.sumochampionship.service;
+
+import com.sumoc.sumochampionship.api.dto.club.ClubDto;
+import com.sumoc.sumochampionship.db.people.Club;
+import com.sumoc.sumochampionship.db.people.WebsiteUser;
+import com.sumoc.sumochampionship.repository.ClubRepository;
+import com.sumoc.sumochampionship.repository.WrestlerRepository;
+import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ClubServiceTest {
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private WrestlerRepository wrestlerRepository;
+
+    @InjectMocks
+    private ClubService clubService;
+
+
+    @Test
+    public void getClubsToUser(){
+        // Arrange
+        int clubNo = 5;
+        Set<Club> clubSet = new HashSet<>();
+        for(int i = 0; i < clubNo; i++){
+            clubSet.add(Club.builder().id((long) i).build());
+        }
+
+        WebsiteUser user = WebsiteUser.builder()
+                .ownedClubs(clubSet)
+                .build();
+
+        // Act
+        List<ClubDto> clubs = clubService.getAllClubsToUser(user);
+
+        // Assert
+        Assertions.assertEquals(clubNo, clubs.size());
+    }
+}

--- a/backend/sumo-championship/src/test/java/com/sumoc/sumochampionship/service/TournamentServiceTest.java
+++ b/backend/sumo-championship/src/test/java/com/sumoc/sumochampionship/service/TournamentServiceTest.java
@@ -133,4 +133,5 @@ class TournamentServiceTest {
         TournamentDto tournamentDto = tournamentService.getTournament(1);
         assertEquals("Tournament 01", tournamentDto.getName());
     }
+
 }

--- a/backend/sumo-championship/src/test/java/com/sumoc/sumochampionship/service/WrestlerServiceTest.java
+++ b/backend/sumo-championship/src/test/java/com/sumoc/sumochampionship/service/WrestlerServiceTest.java
@@ -1,10 +1,13 @@
 package com.sumoc.sumochampionship.service;
 
+import com.sumoc.sumochampionship.api.dto.wrestler.WrestlersDto;
 import com.sumoc.sumochampionship.api.dto.wrestler.WrestlersResponse;
 import com.sumoc.sumochampionship.db.people.Club;
 import com.sumoc.sumochampionship.db.people.Gender;
 import com.sumoc.sumochampionship.db.people.WebsiteUser;
 import com.sumoc.sumochampionship.db.people.Wrestler;
+import com.sumoc.sumochampionship.db.season.Category;
+import com.sumoc.sumochampionship.repository.CategoryRepository;
 import com.sumoc.sumochampionship.repository.WrestlerRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -19,15 +22,15 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class WrestlerServiceTest {
 
+    @Mock
+    private CategoryRepository categoryRepository;
     @Mock
     private WrestlerRepository wrestlerRepository;
 
@@ -42,12 +45,17 @@ public class WrestlerServiceTest {
      */
     @Test
     public void WrestlersResponse_findAllInClubs(){
+        // Arrange
         int wrestlerNumber = 4;
         int pageLength = 2;
         int pageNo = 0;
 
         WebsiteUser user = new WebsiteUser();
-        Club club = new Club();
+        Club club = Club.builder()
+                .name("c")
+                .id(1L)
+                .nationality("Poland")
+                .build();
         user.setOwnedClubs(Set.of(club));
         List<Wrestler> content = new ArrayList<>(wrestlerNumber);
         for(int i = 0; i < wrestlerNumber; i++){
@@ -56,19 +64,140 @@ public class WrestlerServiceTest {
                             .lastname("A")
                             .gender(Gender.MALE)
                             .birthday(LocalDate.of(2002, 10, 24))
+                            .club(club)
                             .build());
         }
         Pageable pageable = PageRequest.of(pageNo, pageLength);
         Page<Wrestler> wrestlerPage = new PageImpl<>(content.subList(0, 2));
         when(wrestlerRepository.findWrestlerByClubIn(Mockito.anyCollection(), Mockito.any())).thenReturn(wrestlerPage);
 
-
+        // Act
         WrestlersResponse wrestlersResponse = wrestlerService.findAllInClubs(user, pageable);
         System.out.println(wrestlersResponse.getWrestlersInfo());
 
+        // Assert
         Assertions.assertEquals(pageLength, wrestlersResponse.getWrestlersInfo().size());
         Assertions.assertEquals(pageNo, wrestlersResponse.getPageNo());
         Assertions.assertEquals(pageLength, wrestlersResponse.getPageSize());
+    }
+
+    @Test
+    public void filterWrestlerToCategoryAge(){
+        // Arrange
+
+        long senior_id = 1;
+        long junior_id = 2;
+        int juniorWrestlerNo = 10;
+        int seniorWrestlerNo = 3;
+        int midWrestlerNo = 7;
+
+        Category senior = Category.builder()
+                .minAge(70)
+                .maxAge(100)
+                .gender(Gender.ALL)
+                .build();
+        Category junior = Category.builder()
+                .minAge(14)
+                .maxAge(18)
+                .gender(Gender.ALL)
+                .build();
+
+        Club club1 = Club.builder().build();
+
+
+
+        List<Wrestler> wrestlers = new ArrayList<>();
+        for(int i = 0; i < juniorWrestlerNo; i++){
+            wrestlers.add(Wrestler.builder()
+                            .club(club1)
+                            .birthday(LocalDate.now().minusYears(17))
+                            .build());
+        }
+
+        for(int i = 0; i < seniorWrestlerNo; i++){
+            wrestlers.add(Wrestler.builder()
+                    .club(club1)
+                    .birthday(LocalDate.now().minusYears(75))
+                    .build());
+        }
+
+        for(int i = 0; i < midWrestlerNo; i++){
+            wrestlers.add(Wrestler.builder()
+                    .club(club1)
+                    .birthday(LocalDate.now().minusYears(35))
+                    .build());
+        }
+
+        WebsiteUser user = WebsiteUser.builder().build();
+        when(categoryRepository.findById(senior_id)).thenReturn(Optional.of(senior));
+        when(categoryRepository.findById(junior_id)).thenReturn(Optional.of(junior));
+        when(wrestlerRepository.findAllByClubIn(Mockito.any())).thenReturn(wrestlers);
+
+        // Act
+        List<WrestlersDto> seniorWrestlers = wrestlerService.filterWrestler(user, senior_id);
+        List<WrestlersDto> juniorWrestlers = wrestlerService.filterWrestler(user, junior_id);
+
+
+        // Assert
+        Assertions.assertEquals(seniorWrestlerNo, seniorWrestlers.size());
+        Assertions.assertEquals(juniorWrestlerNo, juniorWrestlers.size());
+    }
+
+    @Test
+    public void filterWrestlerToCategoryGender(){
+        // Arrange
+
+        long male_id = 1;
+        long female_id = 2;
+        int maleWrestlerNo = 10;
+        int femaleWrestlerNo = 3;
+
+        Category male = Category.builder()
+                .minAge(1)
+                .maxAge(100)
+                .gender(Gender.MALE)
+                .build();
+        Category female = Category.builder()
+                .minAge(1)
+                .maxAge(100)
+                .gender(Gender.FEMALE)
+                .build();
+
+        Club club1 = Club.builder().build();
+
+
+
+        List<Wrestler> wrestlers = new ArrayList<>();
+        for(int i = 0; i < maleWrestlerNo; i++){
+            wrestlers.add(Wrestler.builder()
+                    .club(club1)
+                    .birthday(LocalDate.now().minusYears(17))
+                    .gender(Gender.MALE)
+                    .build());
+        }
+
+        for(int i = 0; i < femaleWrestlerNo; i++){
+            wrestlers.add(Wrestler.builder()
+                    .club(club1)
+                    .birthday(LocalDate.now().minusYears(75))
+                    .gender(Gender.FEMALE)
+                    .build());
+        }
+
+
+        WebsiteUser user = WebsiteUser.builder().build();
+        when(categoryRepository.findById(male_id)).thenReturn(Optional.of(male));
+        when(categoryRepository.findById(female_id)).thenReturn(Optional.of(female));
+        when(wrestlerRepository.findAllByClubIn(Mockito.any())).thenReturn(wrestlers);
+
+        // Act
+        List<WrestlersDto> maleWrestlers = wrestlerService.filterWrestler(user, male_id);
+        List<WrestlersDto> femaleWrestlers = wrestlerService.filterWrestler(user, female_id);
+
+
+        // Assert
+        Assertions.assertEquals(maleWrestlerNo, maleWrestlers.size());
+        Assertions.assertEquals(femaleWrestlerNo, femaleWrestlers.size());
     }
 
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Jira ticket
<!-- Please replace JIRA_LINK with the link to the Jira ticket this Pull Request is related to -->
JIRA_LINK
<!-- [AN-XX](https://agh-student.atlassian.net/browse/AN-XX) -->
[AN-121](https://agh-student.atlassian.net/browse/AN-121)

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Endpoints that has been implemented are:

- **category/to-tournament** - returns list of categories that belongs to tournament (by tournamentId)
- **wrestlers/all** - it has been implemented earlier but logical it belongs to this task too. It returns all wrestlers that are available to requesting user. For example Polish National Trainer will get all Polish Wrestlers.
- **club/to-user** - returns list of clubs that can be managed by requesting user
- **club/to-wrestler** - returns the club where the wrestler trains (by wrestlerId)
- **wrestler/fit-to-category** - returns all wrestlers that can be managed by requesting user **AND** fit fot provided category. For example: for junior category returns players that are between 14-18 years old
- wrestlers-enrollment/enroll-wrestlers - enroll Wrestler to provided category and tournament.

It is important that endpoints: **wrestlers/all**, **club/to-user**, **wrestler/fit-to-category** works only for logged users (due to @AuthenticationPrincipal annotation). It means it will not work until a token-based login system is implemented.

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
Test in Swagger UI.
Also improve earilier tests and add some new in \test directory
